### PR TITLE
Fix timer thread causes window crash

### DIFF
--- a/Project Tracker/EditProgram.xaml.cs
+++ b/Project Tracker/EditProgram.xaml.cs
@@ -364,7 +364,10 @@ namespace Project_Tracker {
 			main.filesRead.Remove(editingFile);
 
 			isStopwatchRunning = false;
-			timerThread.Abort();
+
+			if (timerThread.IsAlive) {
+				timerThread.Abort();
+			}
 		}
 	}
 }


### PR DESCRIPTION
We fixed issue #4 by having the program only abort the thread if it was alive.