### PR TITLE
Cyancoding commit 1

### DIFF
--- a/app/Project Tracker/Project Tracker/EditProgram.xaml.cs
+++ b/app/Project Tracker/Project Tracker/EditProgram.xaml.cs
@@ -357,10 +357,7 @@ namespace Project_Tracker {
 			}
 
 			MainWindow main = new MainWindow();
-			foreach (string file in main.filesRead) {
-				Console.WriteLine(file);
-			}
-			Console.WriteLine(editingFile);
+
 			main.filesRead.Remove(editingFile);
 
 			isStopwatchRunning = false;

--- a/app/Project Tracker/Project Tracker/UpdateWindow.xaml.cs
+++ b/app/Project Tracker/Project Tracker/UpdateWindow.xaml.cs
@@ -45,6 +45,29 @@ namespace Project_Tracker {
 
 			TableRow newRow = null;
 
+			// For some reason the tables put in like really weird spacing if rows are
+			// longer than one line. I coded my own kind of "text-wrap" property. Basically
+			// it waits for 58 characters and then finds the next space. At that point it
+			// inserts a new line. It seems to solve the issue, though I'm sure there could
+			// be some kind of string that might break this (like a really long word or
+			// something I'm not sure. A temporary fix. I suggest making a better method
+			// soon, but it's not a priority.
+			int index = -1;
+			bool isLookingForSpace = false;
+
+			foreach (char c in value) {
+				index++;
+
+				if (c == ' ' && isLookingForSpace) {
+					value = value.Remove(index, 1);
+					value = value.Insert(index, "\n");
+					isLookingForSpace = false;
+				}
+				if (index % 58 == 0 && index > 57) {
+					isLookingForSpace = true;
+				}
+			}
+
 			if (tableCount == 0) { // Update table
 				newRow = table.RowGroups[0].Rows[updateRowsAdded];
 
@@ -78,6 +101,7 @@ namespace Project_Tracker {
 			if (File.Exists(VERSION_FILE)) {
 				File.Delete(VERSION_FILE);
 			}
+			AddRow("I added some row functionality and functionality functionality functionality functionality functionality functionality also changed something that was weird with the spacing of the whole thing.", featureTable, 0);
 			try {
 				using (StreamReader reader = new StreamReader(VERSION_INFO)) {
 					string json = reader.ReadToEnd();

--- a/app/Project Tracker/Project Tracker/UpdateWindow.xaml.cs
+++ b/app/Project Tracker/Project Tracker/UpdateWindow.xaml.cs
@@ -101,7 +101,7 @@ namespace Project_Tracker {
 			if (File.Exists(VERSION_FILE)) {
 				File.Delete(VERSION_FILE);
 			}
-			AddRow("I added some row functionality and functionality functionality functionality functionality functionality functionality also changed something that was weird with the spacing of the whole thing.", featureTable, 0);
+			
 			try {
 				using (StreamReader reader = new StreamReader(VERSION_INFO)) {
 					string json = reader.ReadToEnd();

--- a/install-resources/version.json
+++ b/install-resources/version.json
@@ -1,5 +1,5 @@
 {
-  "Version": "0.7",
+  "Version": "0.6",
   "Updates": [
       "Finished installer.",
       "Changed view program logo.",

--- a/install-resources/version.json
+++ b/install-resources/version.json
@@ -1,5 +1,5 @@
 {
-  "Version": "0.6",
+  "Version": "0.7",
   "Updates": [
       "Finished installer.",
       "Changed view program logo.",


### PR DESCRIPTION
Fixes #29 and fixes #6. Basically we added a soft-wrap module and changed up a few of the variables to keep the Project Tracker from notifying the user every time there was an update after closing the edit-program window (caused by `EditProgram.xaml.cs` initializing `MainWindow.xaml.cs` each time it closed to change the `filesRead` variable).